### PR TITLE
Clean Up README.md, requirements.txt, and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,5 @@ RUN pip install -r requirements.txt
 RUN apt-get update
 RUN apt-get install -y nginx
 ADD nginx_conf /etc/nginx
-ADD .aws/ /root/.aws
 WORKDIR /ihc-image-analysis
 CMD ["./start_docker.sh"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ cd ./<this repo>
 pip install -r requirements.txt
 ```
 
+### Modify ihc-image-analysis/lap/settings.py
+You will need to have a database for setup. Enter this information
+in the usual `django` settings file. We've placed an example, `settings_example.py`.
+
 Up to this point, we've downloaded the source code and installed the required
 python packages. Let's now initialize our database (**note this requires sqlite 
 to be installed on the host machine**).
@@ -26,59 +30,25 @@ python manage.py migrate
 ```
 
 ### Managing the project
-At this point, we've loaded our database, now we'd like to add some administrative abilities so that we can view the data from an admin panel.
+Now we'll want to populate our database with data useful for the application. To 
+do this:
+
+```
+python manage.py loaddata analytics/fixtures/*.json
+python preload_analytics_models.py
+```
+At this point, we've loaded our database, now we'd like to add a user and fire up a test server.
 
 ```
 python manage.py createsuperuser
 python manage.py runserver
 ```
 
-# Utilizing Docker
-Of course, we could "dockerize" our application. We will begin to do this with
-the `Dockerfile` within this repo. To take advantage of the dockerized solution follow
-these commands:
 
+# Stand up the application
 ```
-docker build -t lap .  
-  
-
-
-#Background
-docker run -d \
--p 8000:8000 \
--v $(pwd):/ihc-image-analysis \
---restart always \
-lap
-  
-#Interactive
-docker run -it \
--p 8000:8000 \
--v $(pwd):/ihc-image-analysis \
-lap bash  
+python manage.py runserver 0.0.0.0:8000
 ```
-
-## SPARQL Server
-As part of this project, we are building our own ontology. For research purposes, it is of interest
-to host a SPARQL server (ontop of our DJANGO RESTful interface) to demonstrate the refactor of the ontology.
-To do this, the Python SParql queries are not performant, so we will turn to a 3rd party applicaiton to server
-our triples. We will use [Apache Jena-fuseki](https://jena.apache.org/documentation/fuseki2/index.html). We will
-use a dockerized version from [stain/jena-docker](https://github.com/stain/jena-docker/tree/master/jena-fuseki).
-
-To deploy we use:
-```
-docker run -d \
--p 3030:3030 \
--e ADMIN_PASSWORD=xxxxx \
---restart always \
-stain/jena-fuseki
-```
-
-We then load our `.owl` file. This is a way more performant way to make our SPARQL queries.
-You can demo this resource [here](http://rapid-609.vm.duke.edu:3030).
-
-
-#acinar tubules
-green = proximal
-not = distal
+[0.0.0.0:8000](0.0.0.0:8000)
 
 

--- a/README.md
+++ b/README.md
@@ -41,14 +41,9 @@ At this point, we've loaded our database, now we'd like to add a user and fire u
 
 ```
 python manage.py createsuperuser
-python manage.py runserver
-```
-
-
-# Stand up the application
-```
 python manage.py runserver 0.0.0.0:8000
 ```
+You should now be able to see the application here: 
 [0.0.0.0:8000](0.0.0.0:8000)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ numpy==1.13.1
 six==1.10.0
 SPARQLWrapper==1.8.0
 uritemplate==3.0.0
-git+git://github.com/benneely/lung-map-utils.git
+git+git://github.com/duke-lungmap-team/lung-map-utils.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,11 +23,8 @@ python-dateutil==2.6.0
 pytz==2017.2
 rdflib==4.2.2
 requests==2.13.0
-s3transfer==0.1.10
 numpy==1.13.1
 six==1.10.0
 SPARQLWrapper==1.8.0
-opencv-python==3.2.0.7
-tqdm==4.11.2
 uritemplate==3.0.0
-git+git://github.com/duke-lungmap-team/lung-map-utils.git
+git+git://github.com/benneely/lung-map-utils.git


### PR DESCRIPTION
Notice in the `README`, I've removed docker instructions. Right now, I'm getting 502 errors and it's gonna take some digging to get it operational again. I'd like to put that as an enhancement issue and keep the docker related stuff in here, but not have the README reference it until operational. Also, I'm removing opencv-python==3.2.0.7 because it is referenced twice, so it's still in requirements.txt.